### PR TITLE
Fix cursor bug

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ export default function App() {
   const classes = useStyles();
 
   const [doRunSUSHI, setDoRunSUSHI] = useState(false);
-  const [inputText, setInputText] = useState('Edit FSH Here!');
+  const [inputText, setInputText] = useState('Edit FSH here!');
   const [outputText, setOutputText] = useState('Your JSON Output Will Display Here: ');
   const [isOutputObject, setIsOutputObject] = useState(false);
 

--- a/src/components/CodeMirrorComponent.js
+++ b/src/components/CodeMirrorComponent.js
@@ -25,7 +25,7 @@ export default function CodeMirrorComponent(props) {
     <Box className={classes.box}>
       <CodeMirror
         className="react-codemirror2"
-        value={props.value}
+        value={'Edit FSH here!'}
         options={{
           theme: 'material',
           lineNumbers: true


### PR DESCRIPTION
Fixes a bug where the cursor would jump to the end of the editor text if you tried to edit in the middle of a block of text.

This fixes this bug by only using the `value` prop to specify a default value. Previously, each time the component re-rendered, it put the current `prop.value` text into the editor and moved the cursor back to the beginning. I believe this current approach is the one that works better for the "uncontrolled" component that we are using.